### PR TITLE
Removed location and tag inheritance

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,3 @@
 locals {
-  location            = coalesce(var.location, data.azurerm_resource_group.appliance.location)
-  resource_group_tags = var.inherit_resource_group_tags ? data.azurerm_resource_group.appliance.tags : {}
-  resource_tags       = merge(local.resource_group_tags, var.tags)
-  config_path         = coalesce(var.config_path, "${path.module}/bootstrap.conf")
+  config_path = coalesce(var.config_path, "${path.module}/bootstrap.conf")
 }

--- a/resources.appliance.tf
+++ b/resources.appliance.tf
@@ -1,14 +1,10 @@
-data "azurerm_resource_group" "appliance" {
-  name = var.resource_group_name
-}
-
 resource "azurerm_public_ip" "appliance" {
   name                = local.public_ip_name
   resource_group_name = var.resource_group_name
-  location            = local.location
+  location            = var.location
   allocation_method   = "Static"
 
-  tags = local.resource_tags
+  tags = var.tags
 }
 
 resource "azurerm_network_interface" "appliance" {
@@ -16,7 +12,7 @@ resource "azurerm_network_interface" "appliance" {
 
   name                          = each.value.name
   resource_group_name           = var.resource_group_name
-  location                      = local.location
+  location                      = var.location
   enable_accelerated_networking = local.enable_accelerated_networking
   enable_ip_forwarding          = true
 
@@ -28,13 +24,13 @@ resource "azurerm_network_interface" "appliance" {
     public_ip_address_id          = each.key == "public" && var.attach_public_ip ? azurerm_public_ip.appliance.id : null
   }
 
-  tags = local.resource_tags
+  tags = var.tags
 }
 
 resource "azurerm_linux_virtual_machine" "appliance" {
   name                = var.name
   resource_group_name = var.resource_group_name
-  location            = local.location
+  location            = var.location
 
   size                            = var.size
   admin_username                  = var.admin_username
@@ -82,20 +78,20 @@ resource "azurerm_linux_virtual_machine" "appliance" {
     identity_ids = [var.user_assigned_identity_id]
   }
 
-  tags = local.resource_tags
+  tags = var.tags
 }
 
 resource "azurerm_managed_disk" "logs" {
   name                = local.log_disk_name
   resource_group_name = var.resource_group_name
-  location            = local.location
+  location            = var.location
 
   storage_account_type   = "Standard_LRS"
   create_option          = "Empty"
   disk_size_gb           = var.log_disk_size_gb
   disk_encryption_set_id = var.disk_encryption_set_id
 
-  tags = local.resource_tags
+  tags = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "logs" {

--- a/tests/deployment/resources.appliance.tf
+++ b/tests/deployment/resources.appliance.tf
@@ -33,6 +33,5 @@ module "test_deployment" {
 
   user_assigned_identity_id = azurerm_user_assigned_identity.test_environment.id
 
-  inherit_resource_group_tags = true
-  tags                        = var.tags
+  tags = data.azurerm_resource_group.test_environment.tags
 }

--- a/tests/deployment/resources.environment.tf
+++ b/tests/deployment/resources.environment.tf
@@ -1,10 +1,14 @@
+data "azurerm_resource_group" "test_environment" {
+  name = var.resource_group_name
+}
+
 resource "azurerm_virtual_network" "test_environment" {
   name                = "vnet-test-fgtvm"
   resource_group_name = var.resource_group_name
   location            = var.location
   address_space       = ["10.100.10.0/27"]
 
-  tags = var.tags
+  tags = data.azurerm_resource_group.test_environment.tags
 }
 
 resource "azurerm_subnet" "test_environment" {
@@ -24,7 +28,7 @@ resource "azurerm_network_security_group" "test_environment" {
   resource_group_name = azurerm_virtual_network.test_environment.resource_group_name
   location            = azurerm_virtual_network.test_environment.location
 
-  tags = var.tags
+  tags = data.azurerm_resource_group.test_environment.tags
 }
 
 resource "azurerm_subnet_network_security_group_association" "test_environment" {
@@ -39,5 +43,5 @@ resource "azurerm_user_assigned_identity" "test_environment" {
   resource_group_name = azurerm_virtual_network.test_environment.resource_group_name
   location            = azurerm_virtual_network.test_environment.location
 
-  tags = var.tags
+  tags = data.azurerm_resource_group.test_environment.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,8 +20,7 @@ variable "resource_group_name" {
 
 variable "location" {
   type        = string
-  description = "Location used for the deployed resources. Must be the same as the location used for network resources (virtual network, subnet), which will be used by default."
-  default     = null
+  description = "Location used for the deployed resources. Must be the same as the location used for network resources (virtual network, subnet)."
 }
 
 variable "size" {
@@ -120,12 +119,12 @@ variable "public_interface_ip_address" {
 
 variable "public_subnet_id" {
   type        = string
-  description = "Resource ID of the subnet where the public NIC will be residing."
+  description = "Resource ID of the subnet where the public (internet facing) NIC will be residing."
 }
 
 variable "private_subnet_id" {
   type        = string
-  description = "Resource ID of the subnet where the private NIC will be residing."
+  description = "Resource ID of the subnet where the private (non-internet facing) NIC will be residing."
 }
 
 variable "private_interface_name" {
@@ -158,13 +157,7 @@ variable "tags" {
   default     = {}
 }
 
-variable "inherit_resource_group_tags" {
-  type        = bool
-  description = "Decides whether to inherit the tags from the resource group or not, and appends them to the resource tags."
-  default     = false
-}
-
 variable "user_assigned_identity_id" {
   type        = string
-  description = "Resource ID of the managed identity which the appliance will use for the SDN connector and disk encryption."
+  description = "Resource ID of the managed identity which the appliance will use for the SDN connector functionality and accessing disk encryption keys."
 }


### PR DESCRIPTION
Terraform didn't like to use a resource group resource as a data source input, so removed the tag and location inheritance features. Location is now a required input, and tags can be inherited by setting them as a variable input for the module.