### PR TITLE
Add variable for public_ip_sku, implement use of variable

### DIFF
--- a/resources.appliance.tf
+++ b/resources.appliance.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "appliance" {
   name                = local.public_ip_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  sku                 = "Standard"
+  sku                 = var.public_ip_sku
   allocation_method   = "Static"
 
   tags = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,19 @@ variable "public_ip_name" {
   # }
 }
 
+variable "public_ip_sku" {
+  type        = string
+  description = "SKU of Public IP. Must be set to either Standard or Basic. Defaults to Standard."
+  default     = "Standard"
+
+  validation {
+    condition = (
+      contains(["standard", "basic"], lower(var.public_ip_sku))
+    )
+    error_messagge = "SKU must be set to either Standard or Basic."
+  }
+}
+
 variable "attach_public_ip" {
   type        = bool
   description = "Used for skipping attachment of the public IP to the firewall for HA deployments."

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ variable "public_ip_sku" {
     condition = (
       contains(["standard", "basic"], lower(var.public_ip_sku))
     )
-    error_messagge = "SKU must be set to either Standard or Basic."
+    error_message = "SKU must be set to either Standard or Basic."
   }
 }
 


### PR DESCRIPTION
To make this version backwards compatible with earlier releases, a variable for the Public IP have been added (defaults to currents version former setting, Standard). In pre-released versions it was set to Basic.

This to ensure that the Public IP resource will not get replaced during a module upgrade (from those older versions).